### PR TITLE
Add neonViolet palette and self-host fonts for offline builds

### DIFF
--- a/client/app/layout.tsx
+++ b/client/app/layout.tsx
@@ -1,19 +1,10 @@
 import type { Metadata } from "next";
-import { Geist, Geist_Mono } from "next/font/google";
+import { GeistSans } from "geist/font/sans";
+import { GeistMono } from "geist/font/mono";
 import "./globals.css";
 import QueryProviders from "@/context/QueryProvider";
 import { Toaster } from "@/components/ui/sonner";
 import AuthProvider from "@/context/AuthProvider";
-
-const geistSans = Geist({
-  variable: "--font-geist-sans",
-  subsets: ["latin"],
-});
-
-const geistMono = Geist_Mono({
-  variable: "--font-geist-mono",
-  subsets: ["latin"],
-});
 
 export const metadata: Metadata = {
   title: "Formly",
@@ -28,7 +19,7 @@ export default function RootLayout({
   return (
     <html lang="en">
       <body
-        className={`${geistSans.variable} ${geistMono.variable} antialiased`}
+        className={`${GeistSans.variable} ${GeistMono.variable} antialiased`}
       >
         <QueryProviders>
           <AuthProvider>{children}</AuthProvider>

--- a/client/constants/index.tsx
+++ b/client/constants/index.tsx
@@ -497,12 +497,13 @@ export const FormPalettes = {
   emerald: { background: "#10B981", surface: "#ECFDF5", accent: "#059669" }, // emerald / mint white
   midnight: { background: "#111827", surface: "#F9FAFB", accent: "#2563EB" }, // slate near-black / clean white
   mauve: { background: "#B5979B", surface: "#b59a94", accent: "#8B5E68" }, // original dusty mauve
+  neonViolet: { background: "#2D1B69", surface: "#FAFFEC", accent: "#C8FF3D" }, // Violet Ink bg / lime-tinted white surface / Neon Lime accent
 } as const;
 
 export type FormPaletteName = keyof typeof FormPalettes;
 
 // 👇 Change this one line to switch the form's color scheme.
-export const ActiveFormPalette: FormPaletteName = "sunset";
+export const ActiveFormPalette: FormPaletteName = "neonViolet";
 
 export const FormBackgroundColor = FormPalettes[ActiveFormPalette].background;
 export const FormSurfaceColor = FormPalettes[ActiveFormPalette].surface;

--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -20,6 +20,7 @@
         "axios": "^1.11.0",
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
+        "geist": "^1.7.2",
         "lucide-react": "^0.539.0",
         "next": "15.4.6",
         "next-themes": "^0.4.6",
@@ -4117,6 +4118,15 @@
       "dev": true,
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/geist": {
+      "version": "1.7.2",
+      "resolved": "https://registry.npmjs.org/geist/-/geist-1.7.2.tgz",
+      "integrity": "sha512-Gu5lDFa3pLRyoBlBPf0QIFHVdWAnpco7fS1bJm41jyLPFoguBgiubseUN2oLXMgqZ7uxAxDoXcHMhCY/fOTTgg==",
+      "license": "SIL OPEN FONT LICENSE",
+      "peerDependencies": {
+        "next": ">=13.2.0"
       }
     },
     "node_modules/get-intrinsic": {

--- a/client/package.json
+++ b/client/package.json
@@ -23,6 +23,7 @@
     "axios": "^1.11.0",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
+    "geist": "^1.7.2",
     "lucide-react": "^0.539.0",
     "next": "15.4.6",
     "next-themes": "^0.4.6",


### PR DESCRIPTION
## Summary
- Adds a new `neonViolet` form color palette and sets it as the active palette
- Replaces `next/font/google` (Geist/Geist Mono) with the self-hosted `geist` npm package, so the client Docker build no longer needs to reach Google Fonts (was failing the build in this environment)

## Test plan
- [x] Deployed to formly.akmr.me via `deploy.sh` — client image built and started successfully
- [x] Verified https://formly.akmr.me returns 200 with the new palette live